### PR TITLE
patch for skia: Workaround_glyph_position_at_eol.patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - 'test/**'
     paths:
       - ".github/workflows/*"
       - "script/*"
@@ -14,7 +15,7 @@ on:
         default: 'false'
 
 env:
-  version: m105-305b7c02
+  version: m105-305b7c02-1
 
 jobs:
   macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - 'test/**'
     paths:
       - ".github/workflows/*"
       - "script/*"

--- a/patches/Workaround_glyph_position_at_eol.patch
+++ b/patches/Workaround_glyph_position_at_eol.patch
@@ -1,0 +1,29 @@
+Index: modules/skparagraph/src/TextLine.cpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/modules/skparagraph/src/TextLine.cpp b/modules/skparagraph/src/TextLine.cpp
+--- a/modules/skparagraph/src/TextLine.cpp	(revision 305b7c02b90b248f000b2e48e8621368a22cf887)
++++ b/modules/skparagraph/src/TextLine.cpp	(date 1664452508330)
+@@ -1258,10 +1258,19 @@
+         return { SkToS32(utf16Index) , kDownstream };
+     }
+
++    auto lineTextRange = this->textWithNewlines();
+     PositionWithAffinity result(0, Affinity::kDownstream);
+     this->iterateThroughVisualRuns(true,
+-        [this, dx, &result]
++        [this, dx, &result, lineTextRange]
+         (const Run* run, SkScalar runOffsetInLine, TextRange textRange, SkScalar* runWidthInLine) {
++            auto intersection = lineTextRange.intersection(textRange);
++            if (textRange.width() == 2 && intersection == textRange && lineTextRange.end == textRange.end) {
++                auto text = fOwner->text(textRange);
++                if (text[0] == 13 && text[1] == 10) { // CR/LF
++                    SkASSERT(result.position != 0);
++                    return false; // stop looking, take the last saved `result`
++                }
++            }
+             bool keepLooking = true;
+             *runWidthInLine = this->iterateThroughSingleRunByStyles(
+             run, runOffsetInLine, textRange, StyleType::kNone,

--- a/script/checkout.py
+++ b/script/checkout.py
@@ -52,7 +52,8 @@ def main():
              "13646_Skip_activate-emsdk_for_arm_linux.patch",
              "Fix_glyph_position_and_rects_for_chars_inside_ligatures.patch",
              "13649_fix_assert_when_we're_getting_line_metrics.patch",
-             "10666_allow_to_configure_font_rasterisation_settings_in_paragraph.patch"]
+             "10666_allow_to_configure_font_rasterisation_settings_in_paragraph.patch",
+             "Workaround_glyph_position_at_eol.patch"]
 
   subprocess.check_call(["git", "reset", "--hard"])
   for patch_name in patches:


### PR DESCRIPTION
skia-pack with this change has been already built for testing purposes (and skiko 0.7.34 was built with it).
Now it needs to be added to main branch too. 