### PR TITLE
Windows ARM support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,12 +209,13 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
+        machine: ["x64"]
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
       - uses: actions/checkout@v2
       - shell: bash
-        run: python3 script/check_release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}
+        run: python3 script/check_release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -223,16 +224,50 @@ jobs:
       - shell: bash
         run: python3 script/checkout.py --version ${{ env.version }}
       - shell: bash
-        run: python3 script/build.py --build-type ${{ matrix.build_type }}
+        run: python3 script/build.py --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
       - shell: bash
-        run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}
+        run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
       - uses: actions/upload-artifact@v2
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         with:
-          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-x64.zip
+          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-${{ matrix.machine }}.zip
           path: '*.zip'
       - shell: bash
-        run: python3 script/release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}
+        run: python3 script/release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  windows-arm:
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+        machine: ["arm64"]
+      fail-fast: false
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v2
+      - shell: bash
+        run: python3 script/check_release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: microsoft/setup-msbuild@v1
+      - uses: ilammy/msvc-dev-cmd@v1
+      - shell: bash
+        run: python3 script/checkout.py --version ${{ env.version }}
+      - shell: bash
+        run: python3 script/build.py --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+      - shell: bash
+        run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
+        with:
+          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-${{ matrix.machine }}.zip
+          path: '*.zip'
+      - shell: bash
+        run: python3 script/release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,41 +209,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
-        machine: ["x64"]
-      fail-fast: false
-    steps:
-      - run: git config --global core.autocrlf input
-      - uses: actions/checkout@v2
-      - shell: bash
-        run: python3 script/check_release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
-        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: microsoft/setup-msbuild@v1
-      - uses: ilammy/msvc-dev-cmd@v1
-      - shell: bash
-        run: python3 script/checkout.py --version ${{ env.version }}
-      - shell: bash
-        run: python3 script/build.py --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
-      - shell: bash
-        run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
-      - uses: actions/upload-artifact@v2
-        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
-        with:
-          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-${{ matrix.machine }}.zip
-          path: '*.zip'
-      - shell: bash
-        run: python3 script/release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
-        if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  windows-arm:
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        build_type: [Debug, Release]
-        machine: ["arm64"]
+        machine: ["x64", "arm64"]
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input

--- a/script/build.py
+++ b/script/build.py
@@ -30,22 +30,15 @@ def main():
     'skia_use_system_libwebp=false',
     'skia_use_system_zlib=false',
     'skia_use_sfntly=false',
-    'skia_use_freetype=true',
     'skia_use_system_freetype2=false',
-    # 'skia_use_harfbuzz=true',
     'skia_use_system_harfbuzz=false',
     'skia_pdf_subset_harfbuzz=true',
-    # 'skia_use_icu=true',
     'skia_use_system_icu=false',
-    # 'skia_enable_skshaper=true',
-    # 'skia_enable_svg=true',
     'skia_enable_skottie=true'
   ]
 
   if 'macos' == target or isIos:
     args += [
-      # 'skia_enable_gpu=true',
-      # 'skia_use_gl=true',
       'skia_use_metal=true',
       'extra_cflags_cc=["-frtti"]'
     ]
@@ -75,7 +68,6 @@ def main():
         ]
   elif 'windows' == target:
     args += [
-      # 'skia_use_angle=true',
       'skia_use_direct3d=true',
       'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
     ]


### PR DESCRIPTION
We can build ARM on x86 machine.

Also, remove `skia_use_freetype=true`, because Skia doesn't build with this flag on ARM.

It is safe to remove, because is already `true` by default on Linux, and functions from file SkFontHost_FreeType_* aren't used anywhere in Skia/Skiko on Windows/macOS (skia_use_freetype only affects including these files).

I verified that in 2 ways:
1. Checked that Compose still works with this new Skia on Window/macOs/Linux
2. Tried to build with `skia_use_freetype=true`, but deleted content of SkFontHost_FreeType_* files. It still worked on Windows/macOs, but fails on Linux when we run Compose (skia/skiko don't fail on Compile time)