### PR TITLE
workaround ios_min_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         default: 'false'
 
 env:
-  version: m110-ad42464
+  version: m110-ad42464-1
 
 jobs:
   macos:

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Prebuilt binaries can be found [in releases](https://github.com/JetBrains/skia-p
 ## Building locally
 
 ```sh
-python3 script/checkout.py --version m110-ad42464
+python3 script/checkout.py --version m110-ad42464-1
 python3 script/build.py
-python3 script/archive.py --version m110-ad42464
+python3 script/archive.py --version m110-ad42464-1
 ```
 
 To build a debug build:
 
 ```sh
-python3 script/checkout.py --version m110-ad42464
+python3 script/checkout.py --version m110-ad42464-1
 python3 script/build.py --build-type Debug
-python3 script/archive.py --version m110-ad42464 --build-type Debug
+python3 script/archive.py --version m110-ad42464-1 --build-type Debug
 ```

--- a/script/build.py
+++ b/script/build.py
@@ -44,9 +44,10 @@ def main():
     ]
     if isIos:
       args += ['target_os="ios"']
-      args += ['ios_min_target="11.0"']
       if isIosSim:
         args += ['ios_use_simulator=true']
+      else:
+        args += ['ios_min_target="11.0"']
     else:
       if 'arm64' == machine:
         args += ['extra_cflags=["-stdlib=libc++"]']


### PR DESCRIPTION
Apparently adding `ios_min_target` for arm64 makes the object file look like it's targeting a real device, but not an emulator despite `args += ['ios_use_simulator=true']`


`otool -lv ./Release-iosSim-arm64/libskresources.a` shows such a difference:

`platform IOS` - with `ios_min_target`

`platform IOSSIMULATOR` - without `ios_min_target`

So for now lets skip ios_min_target for simulators. 

____
Some extra details for the future:

`ios_min_target` does nothing more than configuring 3 more flags:
```
if (ios_min_target != "") {
      cflags += [ "-miphoneos-version-min=$ios_min_target" ]
      asmflags += [ "-miphoneos-version-min=$ios_min_target" ]
      ldflags += [ "-miphoneos-version-min=$ios_min_target" ]
    }
```
There're no other usages of `ios_min_target`.
So it seems that `-miphoneos-version-min` somehow confuses clang when targeting arm64 simulator