### PR TITLE
Bump min iOS to 12 - required to build with Xcode 14.3

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -47,7 +47,7 @@ def main():
       if isIosSim:
         args += ['ios_use_simulator=true']
       else:
-        args += ['ios_min_target="11.0"']
+        args += ['ios_min_target="12.0"']
     else:
       if 'arm64' == machine:
         args += ['extra_cflags=["-stdlib=libc++"]']


### PR DESCRIPTION
`/Skia-m110-ad42464-1-iosSim-Release-arm64/src/core/SkTLazy.h:87:24: error: 'value' is unavailable: introduced in iOS 12.0`

See https://github.com/JetBrains/skiko/pull/702