### PR TITLE
Use macos-12 runner and Xcode 13.1 when building iOS targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   macos:
-    runs-on: ${{ fromJson('{"macos":"macos-13","ios":"macos-13","iosSim":"macos-13","tvos":"macos-13","tvosSim":"macos-13"}')[matrix.target] }}
+    runs-on: ${{ fromJson('{"macos":"macos-13","ios":"macos-12","iosSim":"macos-12","tvos":"macos-13","tvosSim":"macos-13"}')[matrix.target] }}
     strategy:
       matrix:
         target: ["macos", "ios", "iosSim", "tvos", "tvosSim"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Select Xcode 13.1 for iOS targets
+        if: ${{ matrix.target == 'ios' || matrix.target == 'iosSim' }}
         run: sudo xcode-select -s /Applications/Xcode_13.1.app
-        if: ${{ matrix.target }} == 'ios' || ${{ matrix.target }} == 'iosSim'
       - name: Print Xcode version
         run: xcodebuild -version
       - run: python3 script/checkout.py --version ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         default: 'false'
 
 env:
-  version: m126-d2aaacc35d-2
+  version: m126-d2aaacc35d-4
 
 jobs:
   macos:
@@ -33,8 +33,8 @@ jobs:
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Select Xcode 14.3.1 for iOS targets
-        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
+      - name: Select Xcode 13.1 for iOS targets
+        run: sudo xcode-select -s /Applications/Xcode_13.1.app
         if: ${{ matrix.target }} == 'ios' || ${{ matrix.target }} == 'iosSim'
       - name: Print Xcode version
         run: xcodebuild -version

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Prebuilt binaries can be found [in releases](https://github.com/JetBrains/skia-p
 ## Building locally
 
 ```sh
-python3 script/checkout.py --version m126-d2aaacc35d-2
+python3 script/checkout.py --version m126-d2aaacc35d-4
 python3 script/build.py
-python3 script/archive.py --version m126-d2aaacc35d-2
+python3 script/archive.py --version m126-d2aaacc35d-4
 ```
 
 To build a debug build:
 
 ```sh
-python3 script/checkout.py --version m126-d2aaacc35d-2
+python3 script/checkout.py --version m126-d2aaacc35d-4
 python3 script/build.py --build-type Debug
-python3 script/archive.py --version m126-d2aaacc35d-2 --build-type Debug
+python3 script/archive.py --version m126-d2aaacc35d-4 --build-type Debug
 ```


### PR DESCRIPTION
**Why:**
It fixes https://youtrack.jetbrains.com/issue/CMP-6721

Previous skia-ios binaries  (m116) were built using **macos-11 agent**, and they are not available anymore.

 Since we ingtegrated m126, we switched to macos-13. macos version determines the default Xcode version used to build.
Downgrading the Xcode version is not a perfect solution, since it's not future-proof. But for the purpose of CM 1.7 release we better use this option.

Xcode 13.1 is not available in macos-13, so we downgrade to macos-12 for ios builds

**How to reproduce in skiko:**
- run `xcodegen` skiko/samples/SkiaMultiplatformSample
- open the generated project in Xcode
- try to run on ios15 simulator, the app crashes:
```
Thread 1 Queue : com.apple.main-thread (serial)
#0	0x0000000101287118 in __abort_with_payload ()
#1	0x0000000101292d7c in abort_with_payload_wrapper_internal ()
#2	0x0000000101292db0 in abort_with_payload ()
#3	0x000000010113c11c in 0x10113c11c ()
#4	0x000000010110d4f4 in 0x10110d4f4 ()
#5	0x0000000101125460 in 0x101125460 ()
#6	0x00000001003ee2e4 in GrMtlGpu::GrMtlGpu(GrDirectContext*, GrContextOptions const&, id<MTLDevice>, id<MTLCommandQueue>) ()
#7	0x00000001003ee25c in GrMtlGpu::Make(GrMtlBackendContext const&, GrContextOptions const&, GrDirectContext*) ()
#8	0x00000001003edf3c in GrDirectContexts::MakeMetal(GrMtlBackendContext const&, GrContextOptions const&) ()
#9	0x00000001003ede58 in GrDirectContexts::MakeMetal(GrMtlBackendContext const&) ()
#10	0x00000001006273fc in org_jetbrains_skia_DirectContext__1nMakeMetal ()
```

Then change the skia version to  `dependencies.skia=m126-d2aaacc35d-3` (it's a test-only skia build, which used Xcode 13 for skia-iosSim build), clean the project, rerun the tasks. The apps works now.

**Investigation:**
The sample also works when we build skia (using Xcode 15) with all optimizations disabled - `-O0` instead of '-O3' (O1 and O2 don't help). Therefore we concluded that newer Xcode version (and thus clang) makes some optimizations incompatible with ios15 simulator (real devices were not affected). 

**Future considerations:**

In the future, GitHub actions will drop Xcode 13 support (it depends on the MacOs version). And we won't be able to use the older version. In that case we might consider building skia-iosSim binaries with optimizations disabled (`-O0`). 
