### PR TITLE
Build Skia with Clang-CL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,7 @@ jobs:
         run: python3 script/build.py --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
       - shell: bash
         run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }} --target windows --machine ${{ matrix.machine }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         with:
           name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-${{ matrix.machine }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 env:
-  version: m126-6fd3120c1b-1
+  version: m126-6fd3120c1b-2
 
 jobs:
   macos:

--- a/script/archive.py
+++ b/script/archive.py
@@ -46,7 +46,7 @@ def main():
     'modules/skunicode/src/*.h',
     'src/base/*.h',
     'src/core/*.h',
-    'src/gpu/gl/*.h',
+    'src/gpu/ganesh/gl/*.h',
     'src/utils/*.h',
     'third_party/externals/angle2/LICENSE',
     'third_party/externals/angle2/include/**/*',

--- a/script/build.py
+++ b/script/build.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-import common, os, subprocess, sys
+import common, os, shutil, subprocess, sys
 
 def main():
   os.chdir(os.path.join(os.path.dirname(__file__), os.pardir, 'skia'))
@@ -86,6 +86,13 @@ def main():
       'skia_use_direct3d=true',
       'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
     ]
+    if 'windows' == host:
+      clang_path = shutil.which('clang-cl.exe')
+      if clang_path != None:
+        args += [
+          'clang_win="' + os.path.dirname(os.path.dirname(clang_path)) + '"',
+          'is_trivial_abi=false',
+        ]
   elif 'android' == target:
     args += [
       'ndk="'+ ndk + '"'

--- a/script/checkout.py
+++ b/script/checkout.py
@@ -49,6 +49,23 @@ def main():
   print("> Fetching ninja")
   subprocess.check_call(["python3", "bin/fetch-ninja"])
 
+  # Patch an issue in Windows toolchain:
+  # Enable delayed environment variable expansion for CMD to make GitHub Actions happy
+  # https://issues.skia.org/issues/393402169
+  with open("gn/toolchain/BUILD.gn", "r") as toolchain_file:
+    toolchain_file_contents = toolchain_file.read()
+
+  toolchain_file_contents = toolchain_file_contents.replace(
+    'shell = "cmd.exe /c',
+    'shell = "cmd.exe /v:on /c',
+  ).replace(
+    r'env_setup = "$shell set \"PATH=%PATH%',
+    r'env_setup = "$shell set \"PATH=!PATH!',
+  )
+
+  with open("gn/toolchain/BUILD.gn", "w") as toolchain_file:
+    toolchain_file.write(toolchain_file_contents)
+
   return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Official Skia documentation suggests that it's [_highly recommended_](https://skia.org/docs/user/build/#highly-recommended-build-with-clang-cl) to build Skia with Clang-CL on Windows, and that this dramatically improves Skia performance with Software rendering and in other areas. This corresponds with my experience, so here it is.

Related PR for Skiko: https://github.com/JetBrains/skiko/pull/1020