### PR TITLE
Build linux arm on ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 env:
-  version: m132-9b3c42e2f9-2
+  version: m132-9b3c42e2f9-3
 
 jobs:
   macos:
@@ -138,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   linux-arm64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         build_type: [ Debug, Release ]
@@ -151,7 +151,7 @@ jobs:
         if: ${{ github.event.inputs.skip_release != 'true' && github.ref == 'refs/heads/main' }}
         with:
             arch: aarch64
-            distro: ubuntu22.04
+            distro: ubuntu20.04
             githubToken: ${{ secrets.GITHUB_TOKEN }}
             # Mount checkout directory as /checkout in the container
             dockerRunArgs: |
@@ -180,7 +180,7 @@ jobs:
         if: ${{ github.event.inputs.skip_release == 'true' || github.ref != 'refs/heads/main' }}
         with:
             arch: aarch64
-            distro: ubuntu22.04
+            distro: ubuntu20.04
             githubToken: ${{ secrets.GITHUB_TOKEN }}
             # Mount checkout directory as /checkout in the container
             dockerRunArgs: |


### PR DESCRIPTION
This is supposedly minimal fix for https://youtrack.jetbrains.com/issue/CMP-7630
I don't remember specifics and will rely on the build. Basically, if this passes, then we can update skiko version